### PR TITLE
Update spree_zones_by_zip_code.gemspec

### DIFF
--- a/spree_zones_by_zip_code.gemspec
+++ b/spree_zones_by_zip_code.gemspec
@@ -3,8 +3,8 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_zones_by_zip_code'
   s.version     = '2.3.0'
-  s.summary     = 'TODO: Add gem summary here'
-  s.description = 'TODO: Add (optional) gem description here'
+  s.summary     = 'Spree zones by ZIP code'
+  s.description = 'Let spree specify zones by zip code.'
   s.required_ruby_version = '>= 2.0.0'
 
   s.author    = 'Víctor'


### PR DESCRIPTION
Rubygems gives a validation error with TODO or FIXME words on gemspec.

+info here: https://github.com/rubygems/rubygems/blob/8876b4c0b38307142c4f44800f5ad9b85e5ea013/lib/rubygems/specification.rb#L1758
